### PR TITLE
Split the timer on/off part of the overlay

### DIFF
--- a/Hearthstone Deck Tracker/Config.cs
+++ b/Hearthstone Deck Tracker/Config.cs
@@ -500,9 +500,18 @@ namespace Hearthstone_Deck_Tracker
 		public bool HideSecrets = false;
 
 		[DefaultValue(false)]
-		public bool HideTimers = false;
+		public bool HideTurnTimer = false;
 
-		[DefaultValue(false)]
+        [DefaultValue(false)]
+        public bool HidePlayerTimer = false;
+
+        [DefaultValue(false)]
+        public bool HideOpponentTimer = false;
+
+        [DefaultValue(7)]
+        public int HideTimerCycle = 7;
+
+        [DefaultValue(false)]
 		public bool HighlightCardsInHand = false;
 
 		[DefaultValue(false)]

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Overlay/OverlayGeneral.xaml
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Overlay/OverlayGeneral.xaml
@@ -32,10 +32,18 @@
                               VerticalAlignment="Top"
                               Checked="CheckboxHideDecksInOverlay_Checked"
                               Unchecked="CheckboxHideDecksInOverlay_Unchecked" />
-                    <CheckBox x:Name="CheckboxHideTimers" Content="Hide timers"
+                    <CheckBox x:Name="CheckboxHideTimers" Content="Hide turn timer"
                               HorizontalAlignment="Left"
-                              VerticalAlignment="Top" Checked="CheckboxHideTimers_Checked"
-                              Unchecked="CheckboxHideTimers_Unchecked" Margin="10,5,0,0" />
+                              VerticalAlignment="Top" Checked="CheckboxHideTurnTimer_Checked"
+                              Unchecked="CheckboxHideTurnTimer_Unchecked" Margin="10,5,0,0" />
+                    <CheckBox x:Name="CheckboxHideTimersPlayer" Content="Hide player timer"
+                              HorizontalAlignment="Left"
+                              VerticalAlignment="Top" Checked="CheckboxHidePlayerTimer_Checked"
+                              Unchecked="CheckboxHidePlayerTimer_Unchecked" Margin="10,5,0,0" />
+                    <CheckBox x:Name="CheckboxHideTimersOpponent" Content="Hide opponent timer"
+                              HorizontalAlignment="Left"
+                              VerticalAlignment="Top" Checked="CheckboxHideOpponentTimer_Checked"
+                              Unchecked="CheckboxHideOpponentTimer_Unchecked" Margin="10,5,0,0" />
                     <CheckBox x:Name="CheckboxHideOpponentCardAge" Content="Hide card-age"
                               HorizontalAlignment="Left" Margin="10,5,0,0" VerticalAlignment="Top"
                               Checked="CheckboxHideOpponentCardAge_Checked"

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Overlay/OverlayGeneral.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Overlay/OverlayGeneral.xaml.cs
@@ -36,7 +36,7 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Overlay
 			CheckboxHideOverlayInSpectator.IsChecked = Config.Instance.HideOverlayInSpectator;
 			CheckboxOverlayCardMarkToolTips.IsChecked = Config.Instance.OverlayCardMarkToolTips;
 			SliderOverlayOpacity.Value = Config.Instance.OverlayOpacity;
-			CheckboxHideTimers.IsChecked = Config.Instance.HideTimers;
+			CheckboxHideTimers.IsChecked = Config.Instance.HideTurnTimer;
 			CheckboxOverlayCardToolTips.IsChecked = Config.Instance.OverlayCardToolTips;
 			CheckboxOverlayAdditionalCardToolTips.IsEnabled = Config.Instance.OverlayCardToolTips;
 			CheckboxOverlayAdditionalCardToolTips.IsChecked = Config.Instance.AdditionalOverlayTooltips;
@@ -222,28 +222,68 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Overlay
 			Config.Save();
 		}
 
-		private void CheckboxHideTimers_Checked(object sender, RoutedEventArgs e)
+		private void CheckboxHideTurnTimer_Checked(object sender, RoutedEventArgs e)
 		{
 			if(!_initialized)
 				return;
-			Config.Instance.HideTimers = true;
-			SaveConfig(true);
+			Config.Instance.HideTurnTimer = true;
+            Config.Instance.HideTimerCycle = Config.Instance.HideTimerCycle - 4;
+            SaveConfig(true);
 		}
 
-		private void CheckboxHideTimers_Unchecked(object sender, RoutedEventArgs e)
+		private void CheckboxHideTurnTimer_Unchecked(object sender, RoutedEventArgs e)
 		{
 			if(!_initialized)
 				return;
-			Config.Instance.HideTimers = false;
-			SaveConfig(true);
+			Config.Instance.HideTurnTimer = false;
+            Config.Instance.HideTimerCycle = Config.Instance.HideTimerCycle + 4;
+            SaveConfig(true);
 		}
 
-		private void SliderOverlayOpacity_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        private void CheckboxHidePlayerTimer_Checked(object sender, RoutedEventArgs e)
+        {
+            if (!_initialized)
+                return;
+            Config.Instance.HidePlayerTimer = true;
+            Config.Instance.HideTimerCycle = Config.Instance.HideTimerCycle - 2;
+            SaveConfig(true);
+        }
+
+        private void CheckboxHidePlayerTimer_Unchecked(object sender, RoutedEventArgs e)
+        {
+            if (!_initialized)
+                return;
+            Config.Instance.HidePlayerTimer = false;
+            Config.Instance.HideTimerCycle = Config.Instance.HideTimerCycle + 2;
+            SaveConfig(true);
+        }
+
+
+        private void CheckboxHideOpponentTimer_Checked(object sender, RoutedEventArgs e)
+        {
+            if (!_initialized)
+                return;
+            Config.Instance.HideOpponentTimer = true;
+            Config.Instance.HideTimerCycle = Config.Instance.HideTimerCycle - 1;
+            SaveConfig(true);
+        }
+
+        private void CheckboxHideOpponentTimer_Unchecked(object sender, RoutedEventArgs e)
+        {
+            if (!_initialized)
+                return;
+            Config.Instance.HideOpponentTimer = false;
+            Config.Instance.HideTimerCycle = Config.Instance.HideTimerCycle + 1;
+            SaveConfig(true);
+        }
+
+
+        private void SliderOverlayOpacity_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
 		{
 			if(!_initialized)
 				return;
 			Config.Instance.OverlayOpacity = SliderOverlayOpacity.Value;
-			SaveConfig(true);
+            SaveConfig(true);
 		}
 
 		private void CheckboxHideOverlay_Checked(object sender, RoutedEventArgs e)

--- a/Hearthstone Deck Tracker/Utility/HotKeys/PredefinedHotKeyActions.cs
+++ b/Hearthstone Deck Tracker/Utility/HotKeys/PredefinedHotKeyActions.cs
@@ -82,13 +82,72 @@ namespace Hearthstone_Deck_Tracker.Utility.HotKeys
 			Core.Overlay.UpdatePosition();
 		}
 
-		[PredefinedHotKeyAction("Toggle overlay: timers", "Turns the timers on the overlay on or off (if the game is running).")]
+		[PredefinedHotKeyAction("Toggle overlay: timers", "Cycling on or off on the timers on the overlay (if the game is running).")]
 		public static void ToggleOverlayTimer()
 		{
 			if(!Core.Game.IsRunning)
 				return;
-			Config.Instance.HideTimers = !Config.Instance.HideTimers;
-			Config.Save();
+
+            /* cycling around the 3 Timers
+             * 
+             *      A(1)
+             * C(4)
+             *      B(2)
+             *      
+             *  0 <-> hiden
+             *  7 <-> all visible
+             */
+
+            switch (Config.Instance.HideTimerCycle)
+            {
+                case 0://--- -> A
+                    Config.Instance.HideOpponentTimer = false;
+                    Config.Instance.HidePlayerTimer = true;
+                    Config.Instance.HideTurnTimer = true;
+                    break;
+                case 1:// A -> B
+                    Config.Instance.HideOpponentTimer = true;
+                    Config.Instance.HidePlayerTimer = false;
+                    Config.Instance.HideTurnTimer = true;
+                    break;
+                case 2:// B -> C
+                    Config.Instance.HideOpponentTimer = true;
+                    Config.Instance.HidePlayerTimer = true;
+                    Config.Instance.HideTurnTimer = false;
+                    break;
+                case 3:// C -> AB
+                    Config.Instance.HideOpponentTimer = false;
+                    Config.Instance.HidePlayerTimer = false;
+                    Config.Instance.HideTurnTimer = true;
+                    break;
+                case 4:// AB -> AC
+                    Config.Instance.HideOpponentTimer = false;
+                    Config.Instance.HidePlayerTimer = true;
+                    Config.Instance.HideTurnTimer = false;
+                    break;
+                case 5:// AC -> BC
+                    Config.Instance.HideOpponentTimer = true;
+                    Config.Instance.HidePlayerTimer = false;
+                    Config.Instance.HideTurnTimer = false;
+                    break;
+                case 6:// BC -> ABC
+                    Config.Instance.HideOpponentTimer = false;
+                    Config.Instance.HidePlayerTimer = false;
+                    Config.Instance.HideTurnTimer = false;
+                    break;
+                case 7:// ABC -> ---
+                    Config.Instance.HideOpponentTimer = true;
+                    Config.Instance.HidePlayerTimer = true;
+                    Config.Instance.HideTurnTimer = true;
+                    break;
+                default:
+                    break;
+            }
+            if (Config.Instance.HideTimerCycle == 7) Config.Instance.HideTimerCycle = 0;
+            else Config.Instance.HideTimerCycle++;
+
+
+            Config.Save();
 			Core.Overlay.UpdatePosition();
 		}
 

--- a/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml.cs
@@ -143,11 +143,13 @@ namespace Hearthstone_Deck_Tracker.Windows
 		public void HideTimers() => LblPlayerTurnTime.Visibility = LblOpponentTurnTime.Visibility = LblTurnTime.Visibility = Hidden;
 
 		public void ShowTimers()
-			=>
-				LblPlayerTurnTime.Visibility =
-				LblOpponentTurnTime.Visibility = LblTurnTime.Visibility = Config.Instance.HideTimers ? Hidden : Visible;
+        {
+            LblPlayerTurnTime.Visibility = Config.Instance.HidePlayerTimer ? Hidden : Visible;
+            LblOpponentTurnTime.Visibility = Config.Instance.HideOpponentTimer ? Hidden : Visible;
+            LblTurnTime.Visibility = Config.Instance.HideTurnTimer ? Hidden : Visible;
+        }
 
-		public void ShowSecrets(bool force = false, HeroClass? heroClass = null)
+        public void ShowSecrets(bool force = false, HeroClass? heroClass = null)
 		{
 			if(Config.Instance.HideSecrets && !force)
 				return;


### PR DESCRIPTION
- Opponent, Player and Turn are 3 separated choices in the option menu
- Shortcut cycle to show/hide each item

fixes #1758